### PR TITLE
Adding configurable web tile sources 

### DIFF
--- a/Dario/Controllers/TileController.cs
+++ b/Dario/Controllers/TileController.cs
@@ -14,13 +14,14 @@ namespace Dario.Controllers
 {
     public class TileController : ApiController
     {
+        readonly ImageFetcher _imageFetcher = new ImageFetcher();
+
         // testurl http://localhost:49430/stamentoner,countries,cities/6/36/39.jpg
         [Route("{layers}/{level:int:min(0)}/{col:int:min(0)}/{row:int:min(0)}.{ext}")]
         public HttpResponseMessage GetTile(string layers, string level, int col, int row,string ext)
         {
-            var mbtiledir = ConfigurationManager.AppSettings["MbTileDir"];
             var lyrs = layers.Split(',');
-             var images = GetTileImages(mbtiledir,lyrs,level,col,row);
+             var images = GetTileImages(lyrs,level,col,row);
 
             if (images.Count > 0)
             {
@@ -36,43 +37,68 @@ namespace Dario.Controllers
             return new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
         }
 
-        private List<Image> GetTileImages(string mbtiledir, IEnumerable<string> lyrs, string level, int col, int row)
+        private List<Image> GetTileImages(IEnumerable<string> lyrs, string level, int col, int row)
         {
             var images = new List<Image>();
-            Image image=null;
             foreach (var lyr in lyrs)
             {
-                KnownTileServers c;
-                if(Enum.TryParse(lyr, true, out c))
-                {
-                    image= BrutTileProvider.GetTile(lyr, level, col, row);
-                }
-                else
-                {
-                    var mbtiledb = mbtiledir + getDataSource(lyr);
-                    if (File.Exists(mbtiledb))
-                    {
-                        // todo: hoe werkt dit?
-                        var ymax = 1 << Int32.Parse(level);
-                        var y = ymax - row - 1;
- 
-
-                        var connectionString = string.Format("Data Source={0}", mbtiledb);
-                        var mbTileProvider = new MbTileProvider(connectionString);
-                        image = mbTileProvider.GetTile(level, col, y);
-                    }
-                }
-
+                var image = FindInAvailableTileSources(lyr, level, col, row);
+                
                 if (image != null)
                 {
                     images.Add(image);
-                }
-
+                } 
             }
             return images;
-        } 
+        }
 
+        private Image FindInAvailableTileSources(string lyr, string level, int col, int row)
+        {
+            return FindInKnownTileSources(lyr, level, col, row)
+                   ?? FindConfiguredTileSources(lyr, level, col, row)
+                   ?? FindInMbTilesTileSources(lyr, level, col, row);
+        }
 
+        private Image FindConfiguredTileSources(string lyr, string level, int col, int row)
+        {
+            var urlTemplate = ConfigurationManager.AppSettings[lyr];
+            return urlTemplate == null ? null : _imageFetcher.Fetch(col, row, level, urlTemplate).Result;
+        }
+
+        private Image FindInMbTilesTileSources(string lyr, string level, int col, int row)
+        {
+            var mbtiledir = ConfigurationManager.AppSettings["MbTileDir"];
+
+            var mbtiledb = mbtiledir + getDataSource(lyr);
+            if (!File.Exists(mbtiledb)) return null;
+
+            // todo: hoe werkt dit?
+            var ymax = 1 << Int32.Parse(level);
+            var y = ymax - row - 1;
+            
+            var connectionString = string.Format("Data Source={0}", mbtiledb);
+            var mbTileProvider = new MbTileProvider(connectionString);
+            return mbTileProvider.GetTile(level, col, y);
+        }
+
+        private static Image FindInKnownTileSources(string lyr, string level, int col, int row)
+        {
+            if (EnumIsDefined< KnownTileServers>(lyr, true))
+            {
+                return BrutTileProvider.GetTile(lyr, level, col, row);
+            }
+            return null;
+        }
+
+        static bool EnumIsDefined<T>(string value, bool ignoreCase = false) where T : struct
+        {
+            if (ignoreCase)
+            {
+                T outParameter;
+                return (Enum.TryParse(value, true, out outParameter));
+            }
+            return Enum.IsDefined(typeof(T), value);
+        }
 
         private string getMediaType(string ext)
         {

--- a/Dario/Dario.csproj
+++ b/Dario/Dario.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Formatters\PngMediaTypeFormatter.cs" />
     <Compile Include="Models\DatasourceTypes.cs" />
     <Compile Include="Models\ImageConvertor.cs" />
+    <Compile Include="Models\ImageFetcher.cs" />
     <Compile Include="Models\JsonResponseMessage.cs" />
     <Compile Include="Providers\MbTileProvider.cs" />
     <Compile Include="Models\Config.cs" />
@@ -234,7 +235,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49430</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:49430/</IISUrl>
+          <IISUrl>http://localhost:49431/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Dario/Models/ImageFetcher.cs
+++ b/Dario/Models/ImageFetcher.cs
@@ -1,0 +1,21 @@
+﻿using System.Drawing;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Dario.Models
+{
+    class ImageFetcher
+    {
+        readonly HttpClient _httpClient = new HttpClient();
+
+        public async Task<Image> Fetch(int col, int row, string level, string urlTemplate)
+        {
+            var url = (string)urlTemplate.Clone();
+            url = url.Replace("{x}", col.ToString(CultureInfo.InvariantCulture));
+            url = url.Replace("{y}", row.ToString(CultureInfo.InvariantCulture));
+            url = url.Replace("{z}", level);
+            return Image.FromStream(await _httpClient.GetStreamAsync(url).ConfigureAwait(false));
+        }
+    }
+}

--- a/Dario/Web.config
+++ b/Dario/Web.config
@@ -7,6 +7,8 @@
   <appSettings>
     <add key="MbTileDir" value="E:\dev\git\bertt\Dario\Dario\data\mbtiles\" />
     <add key="AgsConfigDir" value="E:\dev\git\bertt\Dario\Dario\Config\" />
+    <add key="baselayer" value="http://b.tile.stamen.com/toner-lite/{z}/{x}/{y}.png"/>
+    <add key="transport" value="http://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}"/>
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5" />


### PR DESCRIPTION
It is now possible to add template url's to the web.config with a format like this:
    <add key="baselayer" value="http://b.tile.stamen.com/toner-lite/{z}/{x}/{y}.png"/>
If the key is used in a tile request the template url is called with the level, col and row of the incoming tile request. This allows custom tile sources.